### PR TITLE
tmux: 日本語コピー文字化け修正(OSC52→pbcopy)と現行設定の反映

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,25 +1,152 @@
-# https://blog.catatsuy.org/a/243
+# 参考：https://blog.catatsuy.org/a/243
+# 不満メモ：
+# ~~不満1 ClaudeCodeで音がでない~~ 
+# 不満2 VSCodeでCommand-jすると、`]11;rgb:1818/1818/1818` というなぞの文字列が入る 対処 set -s escape-time 0 → 10 にして解決した。制御文字が入る隙間を入れた
+# ~~不満4 マウス選択したとき、手を話すと選択が解除されてしまう~~ これは、逆に言えば、マウスだけで()文字をクリップボードに貼り付けられるからいいのかも
+# ~~不満5 ターミナルのGUIウィンドウのタブ選択みたいに、そのときTmuxで管理されているセッション？ウィンドウ？が常に表示されてて、それをマウスクリックとかで簡単に切り替えられるようにしてほしい~~ → 解決済み（下記「クリック可能タブ設定」参照）
+# 不満6 Prefixが押されたら、視覚的に分かるようにしてほしい。コマンドが実行されたらそのコマンドが、視覚的に分かるようにしてほしい。
+
+# ターミナル色設定（iTerm2 + tmux で true color を有効化）
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",xterm-256color:Tc,alacritty:Tc"
+
 # Prefix
-set-option -g prefix C-q
-# 日本語環境なら必須？？
-# setw -g utf8 on
-# set -g status-utf8 on
-# status
-# set -g status-interval 10
-# set -g status-bg colour100
-# setw -g window-status-current-fg black
-# setw -g window-status-current-bg white
-# pane-active-border
-# set -g pane-active-border-fg white
-# KeyBindings
-# pane
-unbind 1
-bind 1 break-pane
-bind 2 split-window -v
-bind 3 split-window -h
+set-option -g prefix C-s
+# 設定ファイルを再読み込み
 bind C-r source-file ~/.tmux.conf
-#bind C-k kill-pane
-bind k kill-window
-unbind &
-bind -r ^[ copy-mode
-bind -r ^] paste-buffer
+
+# マウス操作を有効化
+set -g mouse on
+# マウスホイール1回で1行スクロール（デフォルト5行）
+bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 1 scroll-up
+bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 1 scroll-down
+
+# ダブルクリックでペインをズーム（最大化/復元）
+# bind -n DoubleClick1Pane resize-pane -Z
+
+# ステータスバーの更新間隔（秒）
+set -g status-interval 1
+
+# ウィンドウを閉じた時に番号を詰める
+set -g renumber-windows on
+
+# ESCキーの遅延を解消
+set -s escape-time 10
+
+# ヒストリサイズを増やす
+set -g history-limit 10000
+
+# bind S capture-pane -S -10000 \; save-buffer ~/.tmux/logs/capture-#{session_name}-#{window_index}.txt \; display "Saved!"
+
+# スクロールバー表示（常時表示）※tmuxwatchと相性悪いためコメントアウト
+# set -g pane-scrollbars on
+# set -g pane-scrollbars-position right
+
+# viモードを有効化
+set -g mode-keys vi
+set -g status-keys vi
+
+# クリップボード連携: OSC52 (set-clipboard external/on) を無効化し pbcopy 直書きにする
+# 理由: VSCode統合ターミナル(xterm.js)のOSC52デコードがマルチバイトUTF-8をLatin-1
+#       として誤デコードし、日本語コピーが文字化けする (例: 日→æ¥)。
+#       OSC52経路を切り、pbcopyで正しいUTF-8をmacOSクリップボードへ直接書く。
+#       注: SSH先からローカルへOSC52でクリップボード伝播させたい場合は要再検討。
+set -g set-clipboard off
+
+# コピーモードでvで選択開始、yでコピー(pbcopy直書き)
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel pbcopy
+# マウスドラッグ選択でも離した瞬間にpbcopyへ(選択は維持)
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear pbcopy
+
+# ペイン移動をviライクに（hjkl）
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# ペインリサイズをviライクに
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# 新しいペインを現在のディレクトリで開く
+bind '"' split-window -c "#{pane_current_path}"
+bind % split-window -h -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
+
+# ステータスバーの設定
+set -g status-style 'bg=green,fg=black'
+set -g status-left-length 20
+set -g status-right-length 50
+set -g status-left '#[fg=green][#S] '
+set -g status-right '#[fg=yellow]%Y-%m-%d %H:%M:%S'
+
+# === クリック可能タブ設定（不満5対応） ===
+# セッション名クリックでセッション選択ツリー表示（トグル動作）
+bind -n MouseDown1StatusLeft if -F '#{==:#{pane_mode},tree-mode}' 'send-keys q' 'choose-tree -Zs'
+
+# ウィンドウリストをタブ風に表示（Xボタン付き、tmux 3.4以降）
+set -g window-status-format ' #I:#W #[range=user|kill#{window_id}][X]#[norange] '
+set -g window-status-current-format ' #I:#W #[range=user|kill#{window_id}][X]#[norange] '
+set -g window-status-current-style 'bg=blue,fg=white,bold'
+set -g window-status-style 'bg=colour240,fg=white'
+set -g window-status-separator ''
+
+# ステータスバーのウィンドウクリックで切り替え、Xボタンクリックで閉じる
+bind -Troot MouseDown1Status if -F '#{m/r:^kill,#{mouse_status_range}}' {
+  run -C 'kill-window -t#{s/^kill//:mouse_status_range}'
+} {
+  select-window -t =
+}
+# === クリック可能タブ設定ここまで ===
+
+# アクティブペインの境界線を強調
+set -g pane-border-status top
+set -g pane-border-format "#[fg=black,bg=green] #P #{pane_title}"
+# set -g pane-border-format '1---5--10|1---5--20|1---5--30|1---5--40|1---5--50|1---5--60|1---5--70|1---5--90|1---5-100|1---5-110|1---5-120|1---5-130|1---5-140|1---5-150|1---5-160|1---5-170|1---5-180|1---5-190|1---5-200|1---5-210|1---5-220|1---5-230|'
+set -g pane-border-style fg=colour240
+set -g pane-active-border-style fg=green,bold
+set -g pane-border-indicators colour
+
+# === キーバインドカンペ ===
+# Prefix(P): Ctrl-s
+# P+Ctrl-s:セ保存  P+Ctrl-r:セ復元  P+s:セ一覧(x:削除)  P+d:デタッチ
+# P+c:ウ作成  P+&:ウ削除  P+\":ペ横分割  P+%:ペ縦分割  P+x:ペ削除
+# P+h/j/k/l:ペイン移動  P+H/J/K/L:枠リサイズ
+# P+[:コピーモード(v:選択/y:コピー/q:終了)  P+]:ペースト
+# P+r:設定リロード  P+?:ヘルプ  P+f:fzf
+# === キーバインドカンペ ここまで ===
+
+# iTerm2向け設定
+# tmux統合(使わない)：
+#   ターミナルGUIウィンドウとTmuxウィンドウが1対1対応になる
+#   メリット：複数TmuxセッションをGUIウィンドウに分けていて、再起動したときattatchとセッション選択が1回で済む
+#    (tmux統合していないときは開いていたGUIウィンドウの数だけattachしてセッション選択をしなければならない)
+#   How：tmux -CC new-session -A -s sessionA , 復帰時 tmux -CC attach -t sessionA
+# tmux統合時iTerm2のタブ/ウィンドウタイトルにtmuxの情報を表示
+# set-option -g set-titles on
+# set-option -g set-titles-string '#T'
+
+
+# 外部拡張機能 tmux-resurrect
+# セッション保存 prefix + Ctrl-s
+# セッション復帰 prefix + Ctrl-r
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+# ペインの内容も保存（その時のスクロールバック履歴）
+# 古いファイルは公式機能で自動削除される（30日以上前、最低5個は残す）
+set -g @resurrect-capture-pane-contents 'on'
+
+# 外部拡張機能 tmux-continuum（自動保存・自動復元）
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @continuum-save-interval '15'  # 15分ごとに自動保存
+set -g @continuum-restore 'on'        # tmux起動時に自動復元
+
+# 外部拡張機能 tmux-fzf（fzfでtmux操作）
+set -g @plugin 'sainnhe/tmux-fzf'
+TMUX_FZF_LAUNCH_KEY="f"  # prefix + f で起動
+
+
+# === TPM初期化（この行は必ず.tmux.confの最後に置く） ===
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## 概要
VSCode 統合ターミナル(xterm.js)の OSC52 デコードがマルチバイト UTF-8 を Latin-1 として誤デコードし、tmux での日本語コピーが文字化けする問題を修正。

例: `日本語…末尾OK` -> `æ¥æ¬èª«å°¾OK`

## 原因
tmux のデフォルト `set-clipboard external` がコピーを OSC52(base64) で VSCode に渡すが、VSCode 側のデコードがマルチバイト UTF-8 を壊す（ASCII は無事）。

## 対策
- `set -g set-clipboard off` で OSC52 経路を無効化
- `y` / マウスドラッグ選択を `pbcopy` 直書き(copy-pipe)に変更し、正しい UTF-8 を macOS クリップボードへ
- あわせて未コミットだった現行 tmux 設定(prefix C-s / マウス / TPM 等)を反映

## 検証
- tmux内部バッファ・copy-line・pbcopy・base64往復は全てバイト一致を確認
- 修正後、実機(VSCodeターミナル)でコピー->ペーストし文字化けが解消することを確認

## 注意 (トレードオフ)
OSC52 を切ったため、SSH 先の tmux からローカル mac へクリップボードを伝播させる用途では効かなくなる。現状ローカル運用のため問題なし。